### PR TITLE
MAP_ID should match "MAP", not "MAP "

### DIFF
--- a/mrcfile/constants.py
+++ b/mrcfile/constants.py
@@ -15,8 +15,8 @@ from __future__ import (absolute_import, division, print_function,
 
 MRC_FORMAT_VERSION = 20140  # MRC2014 format, version 0
 
-MAP_ID = b'MAP '
-MAP_ID_OFFSET_BYTES = 208  # location of 'MAP ' string in an MRC file
+MAP_ID = b'MAP'
+MAP_ID_OFFSET_BYTES = 208  # location of 'MAP' string in an MRC file
 
 IMAGE_STACK_SPACEGROUP = 0
 VOLUME_SPACEGROUP = 1

--- a/mrcfile/mrcinterpreter.py
+++ b/mrcfile/mrcinterpreter.py
@@ -201,7 +201,7 @@ class MrcInterpreter(MrcObject):
         header.flags.writeable = True
         
         # Check this is an MRC file, and read machine stamp to get byte order
-        if header.map != MAP_ID:
+        if not np.chararray.startswith(header.map, MAP_ID):
             msg = ("Map ID string not found - "
                    "not an MRC file, or file is corrupt")
             if self._permissive:

--- a/mrcfile/mrcobject.py
+++ b/mrcfile/mrcobject.py
@@ -523,7 +523,7 @@ class MrcObject(object):
             print(message, file=print_file)
         
         # Check map ID string
-        if self.header.map != MAP_ID:
+        if not np.chararray.startswith(self.header.map, MAP_ID):
             log("Map ID string is incorrect: found {0}, should be {1}"
                 .format(self.header.map, MAP_ID))
             valid = False

--- a/tests/test_mrcobject.py
+++ b/tests/test_mrcobject.py
@@ -64,7 +64,7 @@ class MrcObjectTest(AssertRaisesRegexMixin, unittest.TestCase):
     
     def test_default_header_is_correct(self):
         header = self.mrcobject.header
-        assert header.map == b'MAP '
+        assert np.chararray.startswith(header.map, constants.MAP_ID)
         assert header.nversion == constants.MRC_FORMAT_VERSION
         
         byte_order = '<' if sys.byteorder == 'little' else '>'


### PR DESCRIPTION
According to the [published spec by Cheng et al.](https://doi.org/10.1016/j.jsb.2015.04.002), the MAP ID at word 53 of the header should be:

> Character string ‘MAP’ to identify file type

This clashes with the definition at http://www.ccpem.ac.uk/mrc_format/mrc2014.php which seems to specify "MAP " (i.e. a space or ASCII code `20`) which seems to be the spec you've followed here.

There are files in the wild (e.g. from MotionCor2) which contain the headers with `b"MAP\x00"` (i.e. a NUL character).

Given the differences in the spec and the fact that the web version says that's it's based on the published paper, I think we should be more generous with our interpretation (à la Postel's Law).

I'm not certain that this is the best way to implement this change but I wanted to start the conversation.