### PR TITLE
add `mrcfile.read()`

### DIFF
--- a/docs/usage_guide.rst
+++ b/docs/usage_guide.rst
@@ -23,6 +23,15 @@ introduction, see the :doc:`overview <readme>`.
    os.chdir(old_cwd)
    shutil.rmtree(tempdir)
 
+Opening vs. reading in mrcfile
+----------------------------------------
+
+Opening a file returns an an instance of the
+:class:`~mrcfile.mrcfile.MrcFile` class which represents an MRC file on
+disk.
+Reading returns an in-memory copy file of the file's contents as a
+`numpy array`, without the associated header or extended header.
+
 Opening MRC files
 -----------------
 
@@ -139,6 +148,14 @@ need to open MRC files, but it is also possible to directly instantiate
    ...     mrc
    ...
    MrcMemmap('tmp.mrc', mode='r')
+
+Reading MRC files
+-----------------
+Data from MRC files can be read using the :func:`mrcfile.read` function.
+.. doctest::
+
+   >>> data = mrcfile.read('tmp.mrc')
+   >>> # do things...
 
 Dealing with large files
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mrcfile/__init__.py
+++ b/mrcfile/__init__.py
@@ -63,6 +63,6 @@ http://www.ccpem.ac.uk/mrc_format/mrc2014.php
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from .load_functions import new, open, open_async, mmap, new_mmap
+from .load_functions import new, open, read, open_async, mmap, new_mmap
 from .validator import validate
 from .version import __version__

--- a/mrcfile/load_functions.py
+++ b/mrcfile/load_functions.py
@@ -17,13 +17,13 @@ from __future__ import (absolute_import, division, print_function,
 import io
 import os
 
+from . import utils
 from .bzip2mrcfile import Bzip2MrcFile
 from .constants import MAP_ID, MAP_ID_OFFSET_BYTES
 from .future_mrcfile import FutureMrcFile
 from .gzipmrcfile import GzipMrcFile
 from .mrcfile import MrcFile
 from .mrcmemmap import MrcMemmap
-from . import utils
 
 
 def new(name, data=None, compression=None, overwrite=False):
@@ -137,6 +137,19 @@ def open(name, mode='r', permissive=False, header_only=False):  # @ReservedAssig
                 NewMrc = Bzip2MrcFile
     return NewMrc(name, mode=mode, permissive=permissive,
                   header_only=header_only)
+
+
+def read(name):
+    """Read an MRC file into a numpy array.
+
+    This function provides a simple interface for reading MRC files.
+
+    Args:
+        name: The file name to read.
+    """
+    with open(name, mode='r', permissive=True) as mrc:
+        data = mrc.data.copy()
+    return data
 
 
 def open_async(name, mode='r', permissive=False):

--- a/tests/test_load_functions.py
+++ b/tests/test_load_functions.py
@@ -49,6 +49,12 @@ class LoadFunctionTest(helpers.AssertRaisesRegexMixin, unittest.TestCase):
         with mrcfile.open(self.example_mrc_name) as mrc:
             assert repr(mrc) == ("MrcFile('{0}', mode='r')"
                                  .format(self.example_mrc_name))
+
+    def test_read_function(self):
+        volume = mrcfile.read(self.example_mrc_name)
+        assert isinstance(volume, np.ndarray)
+        assert volume.shape, volume.dtype == ((20, 20, 20), np.float32)
+        assert volume.flags.writeable is True
     
     def test_gzip_opening(self):
         with mrcfile.open(self.gzip_mrc_name) as mrc:


### PR DESCRIPTION
This PR adds the `mrcfile.read()` function discussed in #28 

One thing I considered is defaulting to a memory mapped read - a quick google suggests there can be disadvantages to this so I thought I'd get your opinion before adding that

I'm not setup for building the docs so that should probably be checked before merge too 🙂 