### PR TITLE
add `mrcfile.write()`

### DIFF
--- a/mrcfile/__init__.py
+++ b/mrcfile/__init__.py
@@ -63,6 +63,6 @@ http://www.ccpem.ac.uk/mrc_format/mrc2014.php
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from .load_functions import new, open, open_async, mmap, new_mmap
+from .load_functions import new, write, open, open_async, mmap, new_mmap
 from .validator import validate
 from .version import __version__

--- a/mrcfile/load_functions.py
+++ b/mrcfile/load_functions.py
@@ -71,6 +71,44 @@ def new(name, data=None, compression=None, overwrite=False):
     return mrc
 
 
+def write(name, data=None, compression=None, overwrite=False, voxel_size=None):
+    """Write a new MRC file.
+
+    Args:
+        name: The file name to use.
+        data: Data to put in the file, as a :class:`numpy array
+            <numpy.ndarray>`. The default is :data:`None`, to create an empty
+            file.
+        compression: The compression format to use. Acceptable values are:
+            :data:`None` (the default; for no compression), ``'gzip'`` or
+            ``'bzip2'``.
+            It's good practice to name compressed files with an appropriate
+            extension (for example, ``.mrc.gz`` for gzip) but this is not
+            enforced.
+        overwrite: Flag to force overwriting of an existing file. If
+            :data:`False` and a file of the same name already exists, the file
+            is not overwritten and an exception is raised.
+        voxel_size: float | 3-tuple
+            The voxel size to be written in the file header.
+
+    Returns:
+        An :class:`~mrcfile.mrcfile.MrcFile` object (or a
+        subclass of it if ``compression`` is specified).
+
+    Raises:
+        :exc:`ValueError`: If the file already exists and overwrite is
+            :data:`False`.
+        :exc:`ValueError`: If the compression format is not recognised.
+
+    Warns:
+        RuntimeWarning: If the data array contains Inf or NaN values.
+    """
+    mrc = new(name, data, compression, overwrite)
+    if voxel_size is not None:
+        mrc.voxel_size = voxel_size
+    mrc.close()
+
+
 def open(name, mode='r', permissive=False, header_only=False):  # @ReservedAssignment
     """Open an MRC file.
     

--- a/tests/test_load_functions.py
+++ b/tests/test_load_functions.py
@@ -198,5 +198,15 @@ class LoadFunctionTest(helpers.AssertRaisesRegexMixin, unittest.TestCase):
             file_size = mrc._iostream.tell() # relies on flush() leaving stream at end
             assert file_size == mrc.header.nbytes + mrc.data.nbytes
 
+    def test_write(self):
+        data_in = np.random.random((10, 10)).astype(np.float16)
+        mrcfile.write(self.temp_mrc_name, data_in)
+        with mrcfile.open(self.temp_mrc_name) as mrc:
+            data_out = mrc.data
+            voxel_size = mrc.voxel_size
+        assert np.allclose(data_in, data_out)
+        for attr in 'xyz':
+            assert getattr(voxel_size, attr) == 0
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_load_functions.py
+++ b/tests/test_load_functions.py
@@ -208,5 +208,6 @@ class LoadFunctionTest(helpers.AssertRaisesRegexMixin, unittest.TestCase):
         for attr in 'xyz':
             assert getattr(voxel_size, attr) == 0
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
as discussed in #28 - here is a simple top level `write` function with an optional pixel size argument

Haven't added docs here but happy to take another pass before merge