### PR TITLE
Allow the extended header to be set in the constructor of the new_mmap

### DIFF
--- a/mrcfile/load_functions.py
+++ b/mrcfile/load_functions.py
@@ -208,7 +208,7 @@ def mmap(name, mode='r', permissive=False):
     return MrcMemmap(name, mode=mode, permissive=permissive)
 
 
-def new_mmap(name, shape, mrc_mode=0, fill=None, overwrite=False):
+def new_mmap(name, shape, mrc_mode=0, fill=None, overwrite=False, extended_header=None, exttyp=None):
     """Create a new, empty memory-mapped MRC file.
 
     This function is useful for creating very large files. The initial contents
@@ -245,6 +245,8 @@ def new_mmap(name, shape, mrc_mode=0, fill=None, overwrite=False):
         overwrite: Flag to force overwriting of an existing file. If
             :data:`False` and a file of the same name already exists, the file
             is not overwritten and an exception is raised.
+        extended_header: The extended header object
+        exttyp: The extended header type
 
     Returns:
         A new :class:`~mrcfile.mrcmemmap.MrcMemmap` object.
@@ -255,6 +257,15 @@ def new_mmap(name, shape, mrc_mode=0, fill=None, overwrite=False):
             :data:`False`.
     """
     mrc = MrcMemmap(name, mode='w+', overwrite=overwrite)
+
+    # Add the extended header and type. We need to do this before creating the
+    # memory mapped file to avoid having to copy lots of data
+    if extended_header is not None:
+        mrc._extended_header = extended_header
+        mrc.header.nsymbt = extended_header.nbytes
+    if exttyp is not None:
+        mrc.header.exttyp = exttyp
+
     dtype = utils.dtype_from_mode(mrc_mode)
     mrc._open_memmap(dtype, shape)
     mrc.update_header_from_data()


### PR DESCRIPTION
This pull request allows the extended_header and exttyp to be set in the new_mmap function prior to the data being allocated for a new mmap. This means we don't have to copy the data when setting the extended header which can take a long time for large files.