### PR TITLE
Extended header unused space fix

### DIFF
--- a/mrcfile/mrcinterpreter.py
+++ b/mrcfile/mrcinterpreter.py
@@ -21,30 +21,30 @@ import warnings
 import numpy as np
 
 from . import utils
-from .dtypes import HEADER_DTYPE, get_ext_header_dtype
+from .dtypes import HEADER_DTYPE
 from .mrcobject import MrcObject
 from .constants import MAP_ID
 
 
 class MrcInterpreter(MrcObject):
-    
+
     """An object which interprets an I/O stream as MRC / CCP4 map data.
-    
+
     The header and data are handled as numpy arrays - see
     :class:`~mrcfile.mrcobject.MrcObject` for details.
-    
+
     :class:`MrcInterpreter` can be used directly, but it is mostly intended as
     a superclass to provide common stream-handling functionality. This can be
     used by subclasses which will handle opening and closing the stream.
-    
+
     This class implements the :meth:`~object.__enter__` and
     :meth:`~object.__exit__` special methods which allow it to be used by the
     Python context manager in a :keyword:`with` block. This ensures that
     :meth:`close` is called after the object is finished with.
-        
+
     When reading the I/O stream, a :exc:`ValueError` is raised if the data is
     invalid in one of the following ways:
-    
+
     #. The header's ``map`` field is not set correctly to confirm the file
        type.
     #. The machine stamp is invalid and so the data's byte order cannot be
@@ -54,7 +54,7 @@ class MrcInterpreter(MrcObject):
     #. The file is not large enough for the specified extended header size.
     #. The data block is not large enough for the specified data type and
        dimensions.
-    
+
     :class:`MrcInterpreter` offers a permissive read mode for handling
     problematic files. If ``permissive`` is set to :data:`True` and any of the
     validity checks fails, a :mod:`warning <warnings>` is issued instead of an
@@ -64,34 +64,34 @@ class MrcInterpreter(MrcObject):
     :data:`None`. In this case, it might be possible to inspect and correct the
     header, and then call :meth:`_read` again to read the data correctly. See
     the :doc:`usage guide <../usage_guide>` for more details.
-    
+
     Methods:
-    
+
     * :meth:`flush`
     * :meth:`close`
-    
+
     Methods relevant to subclasses:
-    
+
     * :meth:`_read`
     * :meth:`_read_data`
     * :meth:`_read_bytearray_from_stream`
-    
+
     """
-    
+
     def __init__(self, iostream=None, permissive=False, header_only=False,
                  **kwargs):
         """Initialise a new MrcInterpreter object.
-        
+
         This initialiser reads the stream if it is given. In general,
         subclasses should call :meth:`__init__` without giving an ``iostream``
         argument, then set the ``_iostream`` attribute themselves and call
         :meth:`_read` when ready.
-        
+
         To use the MrcInterpreter class directly, pass a stream when creating
         the object (or for a write-only stream, create an MrcInterpreter with
         no stream, call :meth:`._create_default_attributes` and set the
         ``_iostream`` attribute directly).
-        
+
         Args:
             iostream: The I/O stream to use to read and write MRC data. The
                 default is :data:`None`.
@@ -99,7 +99,7 @@ class MrcInterpreter(MrcObject):
                 :data:`False`.
             header_only: Only read the header (and extended header) from the
                 file. The default is :data:`False`.
-        
+
         Raises:
             :exc:`ValueError`: If ``iostream`` is given, the data it contains
                 cannot be interpreted as a valid MRC file and ``permissive``
@@ -114,34 +114,34 @@ class MrcInterpreter(MrcObject):
                 number of bytes in the corresponding dtype.
         """
         super(MrcInterpreter, self).__init__(**kwargs)
-        
+
         self._iostream = iostream
         self._permissive = permissive
-        
+
         # If iostream is given, initialise by reading it
         if self._iostream is not None:
             self._read(header_only)
-    
+
     def __enter__(self):
         """Called by the context manager at the start of a :keyword:`with`
         block.
-        
+
         Returns:
             This object (``self``).
         """
         return self
-    
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Called by the context manager at the end of a :keyword:`with`
         block.
-        
+
         This ensures that the :meth:`close` method is called.
         """
         self.close()
-    
+
     def __del__(self):
         """Attempt to flush the stream when this object is garbage collected.
-        
+
         It's better not to rely on this - instead, use a :keyword:`with`
         block or explicitly call the :meth:`close` method.
         """
@@ -149,10 +149,10 @@ class MrcInterpreter(MrcObject):
             self.close()
         except Exception:
             pass
-    
+
     def _read(self, header_only=False):
         """Read the header, extended header and data from the I/O stream.
-        
+
         Before calling this method, the stream should be open and positioned at
         the start of the header. This method will advance the stream to the end
         of the data block (or the end of the extended header if ``header_only``
@@ -161,7 +161,7 @@ class MrcInterpreter(MrcObject):
         Args:
             header_only: Only read the header and extended header from the
                 stream. The default is :data:`False`.
-        
+
         Raises:
             :exc:`ValueError`: If the data in the stream cannot be interpreted
                  as a valid MRC file and ``permissive`` is :data:`False`.
@@ -177,10 +177,10 @@ class MrcInterpreter(MrcObject):
 
     def _read_header(self):
         """Read the MRC header from the I/O stream.
-        
+
         The header will be read from the current stream position, and the
         stream will be advanced by 1024 bytes.
-        
+
         Raises:
             :exc:`ValueError`: If the data in the stream cannot be interpreted
                  as a valid MRC file and ``permissive`` is :data:`False`.
@@ -193,7 +193,7 @@ class MrcInterpreter(MrcObject):
         header_arr, bytes_read = self._read_bytearray_from_stream(HEADER_DTYPE.itemsize)
         if bytes_read < HEADER_DTYPE.itemsize:
             raise ValueError("Couldn't read enough bytes for MRC header")
-        
+
         # Use a recarray to allow access to fields as attributes
         # (e.g. header.mode instead of header['mode'])
         header = np.frombuffer(header_arr, dtype=HEADER_DTYPE).reshape(()).view(np.recarray)
@@ -219,10 +219,10 @@ class MrcInterpreter(MrcObject):
                 warnings.warn(str(err), RuntimeWarning)
             else:
                 raise
-        
+
         # Create a new dtype with the correct byte order and update the header
         header.dtype = header.dtype.newbyteorder(byte_order)
-        
+
         # Check mode is valid; if not, try the opposite byte order
         # (Some MRC files have been seen 'in the wild' that are correct except
         # that the machine stamp indicates the wrong byte order.)
@@ -243,19 +243,17 @@ class MrcInterpreter(MrcObject):
                     # Neither byte order gives a valid mode. Ignore for now,
                     # and a warning will be issued by _read_data()
                     pass
-        
+
         header.flags.writeable = not self._read_only
         self._header = header
-    
+
     def _read_extended_header(self):
         """Read the extended header from the stream.
-        
+
         If there is no extended header, a zero-length array is assigned to the
         extended_header attribute.
-        
-        If the extended header is recognised as FEI microscope metadata (by
-        'FEI1' or 'FEI2' in the header's ``exttyp`` field), its dtype is set
-        appropriately. Otherwise, the dtype is set as void (``'V1'``).
+
+        The dtype is set as void (``'V1'``).
 
         Raises:
             :exc:`ValueError`: If the stream is not long enough to contain the
@@ -263,9 +261,6 @@ class MrcInterpreter(MrcObject):
                 is :data:`False`.
 
         Warns:
-            RuntimeWarning: If the header's ``exttyp`` field is set to 'FEI1'
-                or 'FEI2' but the extended header's size is not a multiple of
-                the number of bytes in the FEI metadata dtype.
             RuntimeWarning: If the stream is not long enough to contain the
                 extended header indicated by the header and ``permissive``
                 is :data:`True`.
@@ -284,22 +279,11 @@ class MrcInterpreter(MrcObject):
 
         self._extended_header = np.frombuffer(ext_header_arr, dtype='V1')
 
-        # Use the header's byte order for the extended header
-        dtype = get_ext_header_dtype(self.header.exttyp,
-                                     self.header.mode.dtype.byteorder)
-        if dtype is not None:
-            try:
-                self._extended_header.dtype = dtype
-            except ValueError:
-                warnings.warn("File has exttyp '{}' but the extended header "
-                              "cannot be interpreted as that type"
-                              .format(self.header.exttyp), RuntimeWarning)
-
         self._extended_header.flags.writeable = not self._read_only
-    
+
     def _read_data(self, max_bytes=0):
         """Read the data array from the stream.
-        
+
         This method uses information from the header to set the data array's
         shape and dtype.
 
@@ -328,9 +312,9 @@ class MrcInterpreter(MrcObject):
                 return
             else:
                 raise
-        
+
         shape = utils.data_shape_from_header(self.header)
-        
+
         nbytes = dtype.itemsize
         for axis_length in shape:
             nbytes *= axis_length
@@ -346,7 +330,7 @@ class MrcInterpreter(MrcObject):
                 raise ValueError(msg)
 
         data_arr, bytes_read = self._read_bytearray_from_stream(nbytes)
-        
+
         if bytes_read < nbytes:
             msg = ("Expected {0} bytes in data block but could only read {1}"
                    .format(nbytes, bytes_read))
@@ -356,7 +340,7 @@ class MrcInterpreter(MrcObject):
                 return
             else:
                 raise ValueError(msg)
-        
+
         self._data = np.frombuffer(data_arr, dtype=dtype).reshape(shape)
         self._data.flags.writeable = not self._read_only
 
@@ -376,7 +360,7 @@ class MrcInterpreter(MrcObject):
         result_array = bytearray(number_of_bytes)
         bytes_read = self._iostream.readinto(result_array)
         return result_array, bytes_read
-    
+
     def close(self):
         """Flush to the stream and clear the header and data attributes."""
         if self._header is not None and not self._iostream.closed:
@@ -384,13 +368,13 @@ class MrcInterpreter(MrcObject):
         self._header = None
         self._extended_header = None
         self._close_data()
-    
+
     def flush(self):
         """Flush the header and data arrays to the I/O stream.
-        
+
         This implementation seeks to the start of the stream, writes the
         header, extended header and data arrays, and then truncates the stream.
-        
+
         Subclasses should override this implementation for streams which do not
         support :meth:`~io.IOBase.seek` or :meth:`~io.IOBase.truncate`.
         """

--- a/mrcfile/mrcobject.py
+++ b/mrcfile/mrcobject.py
@@ -22,23 +22,24 @@ import warnings
 import numpy as np
 
 from . import utils
-from .dtypes import HEADER_DTYPE, VOXEL_SIZE_DTYPE, NSTART_DTYPE
+from .dtypes import (HEADER_DTYPE, VOXEL_SIZE_DTYPE, NSTART_DTYPE,
+                     get_ext_header_dtype)
 from .constants import (MAP_ID, IMAGE_STACK_SPACEGROUP, VOLUME_SPACEGROUP,
                         VOLUME_STACK_SPACEGROUP)
 
 
 class MrcObject(object):
-    
+
     """An object representing image or volume data in the MRC format.
-    
+
     The header, extended header and data are stored as numpy arrays and
     exposed as read-only attributes. To replace the data or extended header,
     call :meth:`set_data` or :meth:`set_extended_header`. The header cannot be
     replaced but can be modified in place.
-    
+
     Voxel size is exposed as a writeable attribute, but is calculated
     on-the-fly from the header's ``cella`` and ``mx``/``my``/``mz`` fields.
-    
+
     Three-dimensional data can represent either a stack of 2D images, or a 3D
     volume. This is indicated by the header's ``ispg`` (space group) field,
     which is set to 0 for image data and >= 1 for volume data. The
@@ -47,7 +48,7 @@ class MrcObject(object):
     information stored in the data array. For 3D data, the
     :meth:`set_image_stack` and :meth:`set_volume` methods can be used to
     switch between image stack and volume interpretations of the data.
-    
+
     If the data contents have been changed, you can use the
     :meth:`update_header_from_data` and :meth:`update_header_stats` methods to
     make the header consistent with the data. These methods are called
@@ -58,17 +59,17 @@ class MrcObject(object):
     data array and so can be slow for very large arrays. If necessary, the
     :meth:`reset_header_stats` method can be called to set the header fields to
     indicate that the statistics are undetermined.
-    
+
     Attributes:
-    
+
     * :attr:`header`
     * :attr:`extended_header`
     * :attr:`data`
     * :attr:`voxel_size`
     * :attr:`nstart`
-    
+
     Methods:
-    
+
     * :meth:`set_extended_header`
     * :meth:`set_data`
     * :meth:`is_single_image`
@@ -83,58 +84,58 @@ class MrcObject(object):
     * :meth:`print_header`
     * :meth:`get_labels`
     * :meth:`add_label`
-    
+
     Attributes and methods relevant to subclasses:
-    
+
     * ``_read_only``
     * :meth:`_check_writeable`
     * :meth:`_create_default_attributes`
     * :meth:`_close_data`
     * :meth:`_set_new_data`
-    
+
     """
-    
+
     def __init__(self, **kwargs):
         """Initialise a new :class:`MrcObject`.
-        
+
         This initialiser deliberately avoids creating any arrays and simply
         sets the header, extended header and data attributes to :data:`None`.
         This allows subclasses to call :meth:`__init__` at the start of their
         initialisers and then set the attributes themselves, probably by
         reading from a file, or by calling :meth:`_create_default_attributes`
         for a new empty object.
-        
+
         Note that this behaviour might change in future: this initialiser could
         take optional arguments to allow the header and data to be provided
         by the caller, or might create the standard empty defaults rather than
         setting the attributes to :data:`None`.
         """
         super(MrcObject, self).__init__(**kwargs)
-        
+
         # Set empty default attributes
         self._header = None
         self._extended_header = None
         self._data = None
         self._read_only = False
-    
+
     def _check_writeable(self):
         """Check that this MRC object is writeable.
-        
+
         Raises:
             :exc:`ValueError`: If this object is read-only.
         """
         if self._read_only:
             raise ValueError('MRC object is read-only')
-    
+
     def _create_default_attributes(self):
         """Set valid default values for the header and data attributes."""
         self._create_default_header()
         self._extended_header = np.empty(0, dtype='V1')
         self._set_new_data(np.empty(0, dtype=np.int8))
-    
+
     def _create_default_header(self):
         """Create a default MRC file header.
-        
+
         The header is initialised with standard file type and version
         information, default values for some essential fields, and zeros
         elsewhere. The first text label is also set to indicate the file was
@@ -145,10 +146,10 @@ class MrcObject(object):
         header.map = MAP_ID
         header.nversion = 20141  # current MRC 2014 format version
         header.machst = utils.machine_stamp_from_byte_order(header.mode.dtype.byteorder)
-        
+
         # Default space group is P1
         header.ispg = VOLUME_SPACEGROUP
-        
+
         # Standard cell angles all 90.0 degrees
         default_cell_angle = 90.0
         header.cellb.alpha = default_cell_angle
@@ -157,58 +158,100 @@ class MrcObject(object):
         # (this can also be achieved by assigning a 3-tuple to header.cellb
         # directly but using the sub-fields individually is easier to read and
         # understand)
-        
+
         # Standard axes: columns = X, rows = Y, sections = Z
         header.mapc = 1
         header.mapr = 2
         header.maps = 3
-        
+
         time = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         header.label[0] = '{0:40s}{1:>39s} '.format('Created by mrcfile.py',
                                                     time)
         header.nlabl = 1
-        
+
         self.reset_header_stats()
-    
+
     @property
     def header(self):
         """Get the header as a :class:`numpy record array <numpy.recarray>`."""
         return self._header
-    
+
     @property
     def extended_header(self):
         """Get the extended header as a :class:`numpy array <numpy.ndarray>`.
-        
-        If this :class:`MrcObject` was read from a file and the extended header
-        type was recognised, its dtype will be set appropriately. (Currently
-        the only supported types are ``'FEI1'`` and ``'FEI2'``.) Otherwise, the
-        dtype will be void (raw data, dtype ``'V'``). If the actual data type
+
+        The dtype will be void (raw data, dtype ``'V'``). If the actual data type
         of the extended header is known, the dtype of the array can be changed
-        to match.
-        
+        to match. For supported types (e.g. ``'FEI1'`` and ``'FEI2'`), the
+        indexed part of the extended header (excluding any zero padding) can be
+        accessed using :meth:`indexed_extended_header`
+
         The extended header may be modified in place. To replace it completely,
         call :meth:`set_extended_header`.
         """
         return self._extended_header
-    
+
+    @property
+    def indexed_extended_header(self):
+        """Get the indexed part of the extended header as a
+        :class:`numpy array <numpy.ndarray>` with the appropriate dtype set.
+        Currently only ``'FEI1'`` and ``'FEI2'` extended headers are supported.
+        Modifications to the indexed extended header will not change the
+        extended header data recorded in this :class:`MrcObject`. If the
+        extended header type is unrecognised or extended header data is not of
+        sufficient length a warning will be produced and the indexed extended
+        header will be None."""
+
+        # Use the header's byte order for the extended header
+        dtype = get_ext_header_dtype(self.header.exttyp,
+                                     self.header.mode.dtype.byteorder)
+
+        # Interpret one element
+        try:
+            if self._extended_header.size < dtype.itemsize:
+                raise ValueError
+            first = self._extended_header[0:dtype.itemsize]
+            first.dtype = dtype
+            if first["Metadata size"][0] != dtype.itemsize:
+                raise ValueError
+        except ValueError:
+            warnings.warn("The header has exttyp '{}' but the extended header "
+                            "cannot be interpreted as that type"
+                            .format(self.header.exttyp), RuntimeWarning)
+            return None
+
+        nbytes = int(self.header["nz"]) * dtype.itemsize
+        try:
+            if self._extended_header.size < nbytes:
+                raise ValueError
+            full = self._extended_header[0:nbytes]
+            full.dtype = dtype
+        except ValueError:
+            warnings.warn("The header has exttyp '{}' but the extended header "
+                            "cannot be interpreted as that type"
+                            .format(self.header.exttyp), RuntimeWarning)
+            return None
+
+        return full
+
     def set_extended_header(self, extended_header):
         """Replace the extended header.
-        
+
         If you set the extended header you should also set the
         ``header.exttyp`` field to indicate the type of extended header.
         """
         self._check_writeable()
         self._extended_header = extended_header
         self.header.nsymbt = extended_header.nbytes
-    
+
     @property
     def data(self):
         """Get the data as a :class:`numpy array <numpy.ndarray>`."""
         return self._data
-    
+
     def set_data(self, data):
         """Replace the data array.
-        
+
         This replaces the current data with the given array (or a copy of it),
         and updates the header to match the new data dimensions. The data
         statistics (min, max, mean and rms) stored in the header will also be
@@ -218,37 +261,37 @@ class MrcObject(object):
             RuntimeWarning: If the data array contains Inf or NaN values.
         """
         self._check_writeable()
-        
+
         # Check if the new data's dtype is valid without changes
         mode = utils.mode_from_dtype(data.dtype)
         new_dtype = (utils.dtype_from_mode(mode)
                      .newbyteorder(data.dtype.byteorder))
-        
+
         # Copy the data if necessary to ensure correct dtype and C ordering
         new_data = np.asanyarray(data, new_dtype, order='C')
-        
+
         # Replace the old data array with the new one, and update the header
         self._close_data()
         self._set_new_data(new_data)
         self.update_header_from_data()
         self.update_header_stats()
-    
+
     def _close_data(self):
         """Close the data array."""
         self._data = None
-    
+
     def _set_new_data(self, data):
         """Replace the data array with a new one.
-        
+
         The new data array is not checked - it must already be valid for use in
         an MRC file.
         """
         self._data = data
-    
+
     @property
     def voxel_size(self):
         """Get or set the voxel size in angstroms.
-        
+
         The voxel size is returned as a structured NumPy :class:`record array
         <numpy.recarray>` with three fields (x, y and z). For example:
 
@@ -262,16 +305,16 @@ class MrcObject(object):
         voxel size in the file -- to prevent this being overlooked
         accidentally, the writeable flag is set to :data:`False` on the
         voxel_size array.
-        
+
         To set the voxel size, assign a new value to the voxel_size attribute.
         You may give a single number, a 3-tuple ``(x, y ,z)`` or a modified
         version of the voxel_size array. The following examples are all
         equivalent:
-        
+
         >>> mrc.voxel_size = 1.0
-        
+
         >>> mrc.voxel_size = (1.0, 1.0, 1.0)
-        
+
         >>> vox_sizes = mrc.voxel_size
         >>> vox_sizes.flags.writeable = True
         >>> vox_sizes.x = 1.0
@@ -285,7 +328,7 @@ class MrcObject(object):
         sizes = np.rec.array((x, y, z), VOXEL_SIZE_DTYPE)
         sizes.flags.writeable = False
         return sizes
-    
+
     @voxel_size.setter
     def voxel_size(self, voxel_size):
         self._check_writeable()
@@ -301,10 +344,10 @@ class MrcObject(object):
                 # If the item() method doesn't exist, assume we have a 3-tuple
                 sizes = voxel_size
         self._set_voxel_size(*sizes)
-    
+
     def _set_voxel_size(self, x_size, y_size, z_size):
         """Set the voxel size.
-        
+
         Args:
             x_size: The voxel size in the X direction, in angstroms
             y_size: The voxel size in the Y direction, in angstroms
@@ -393,45 +436,45 @@ class MrcObject(object):
 
     def is_single_image(self):
         """Identify whether the file represents a single image.
-        
+
         Returns:
             :data:`True` if the data array is two-dimensional.
         """
         return self.data.ndim == 2
-    
+
     def is_image_stack(self):
         """Identify whether the file represents a stack of images.
-        
+
         Returns:
             :data:`True` if the data array is three-dimensional and the space group
             is zero.
         """
         return (self.data.ndim == 3
                 and self.header.ispg == IMAGE_STACK_SPACEGROUP)
-    
+
     def is_volume(self):
         """Identify whether the file represents a volume.
-        
+
         Returns:
             :data:`True` if the data array is three-dimensional and the space
             group is not zero.
         """
         return (self.data.ndim == 3
                 and self.header.ispg != IMAGE_STACK_SPACEGROUP)
-    
+
     def is_volume_stack(self):
         """Identify whether the file represents a stack of volumes.
-        
+
         Returns:
             :data:`True` if the data array is four-dimensional.
         """
         return self.data.ndim == 4
-    
+
     def set_image_stack(self):
         """Change three-dimensional data to represent an image stack.
-        
+
         This method changes the space group number (``header.ispg``) to zero.
-        
+
         Raises:
             :exc:`ValueError`: If the data array is not three-dimensional.
         """
@@ -440,13 +483,13 @@ class MrcObject(object):
             raise ValueError('Only 3D data can be changed into an image stack')
         self.header.ispg = IMAGE_STACK_SPACEGROUP
         self.header.mz = 1
-    
+
     def set_volume(self):
         """Change three-dimensional data to represent a volume.
-        
+
         If the space group was previously zero (representing an image stack),
         this method sets it to one. Otherwise the space group is not changed.
-        
+
         Raises:
             :exc:`ValueError`: If the data array is not three-dimensional.
         """
@@ -456,24 +499,24 @@ class MrcObject(object):
         if self.is_image_stack():
             self.header.ispg = VOLUME_SPACEGROUP
             self.header.mz = self.header.nz
-    
+
     def update_header_from_data(self):
         """Update the header from the data array.
-        
+
         This function updates the header byte order and machine stamp to match
         the byte order of the data. It also updates the file mode, space group
         and the dimension fields ``nx``, ``ny``, ``nz``, ``mx``, ``my`` and
         ``mz``.
-        
+
         If the data is 2D, the space group is set to 0 (image stack). For 3D
         data the space group is not changed, and for 4D data the space group is
         set to 401 (simple P1 volume stack) unless it is already in the volume
         stack range (401--630).
-        
+
         This means that new 3D data will be treated as an image stack if the
         previous data was a single image or image stack, or as a volume if the
         previous data was a volume or volume stack.
-        
+
         Note that this function does *not* update the data statistics fields in
         the header (``dmin``, ``dmax``, ``dmean`` and ``rms``). Use the
         :meth:`update_header_stats` function to update the statistics.
@@ -483,11 +526,11 @@ class MrcObject(object):
         array need to be inspected.)
         """
         self._check_writeable()
-        
+
         # Check the dtype is one we can handle and update mode to match
         header = self.header
         header.mode = utils.mode_from_dtype(self.data.dtype)
-        
+
         # Ensure header byte order and machine stamp match the data's byte order
         data_byte_order = self.data.dtype.byteorder
         header_byte_order = header.mode.dtype.byteorder
@@ -497,7 +540,7 @@ class MrcObject(object):
             header.dtype = header.dtype.newbyteorder(data_byte_order)
         header.machst = utils.machine_stamp_from_byte_order(header.mode.dtype
                                                             .byteorder)
-        
+
         shape = self.data.shape
         axes = len(shape)
         if axes == 2:
@@ -526,11 +569,11 @@ class MrcObject(object):
             header.nz = shape[0] * shape[1]
         else:
             raise ValueError('Data must be 2-, 3- or 4-dimensional')
-    
+
     def update_header_stats(self):
         """Update the header's ``dmin``, ``dmax``, ``dmean`` and ``rms`` fields
         from the data.
-        
+
         Note that this can take some time with large files, particularly with
         files larger than the currently available memory.
 
@@ -561,19 +604,19 @@ class MrcObject(object):
                 self.header.rms = self.data.std(dtype=np.float32)
         else:
             self.reset_header_stats()
-    
+
     def reset_header_stats(self):
         """Set the header statistics to indicate that the values are unknown."""
         self._check_writeable()
-        
+
         self.header.dmin = 0
         self.header.dmax = -1
         self.header.dmean = -2
         self.header.rms = -1
-    
+
     def print_header(self, print_file=None):
         """Print the contents of all header fields.
-        
+
         Args:
             print_file: The output text stream to use for printing the header.
                 This is passed directly to the ``file`` argument of Python's
@@ -628,13 +671,13 @@ class MrcObject(object):
             raise ValueError("Label value has more than 80 bytes")
         self.header.label[self.header.nlabl] = label
         self.header.nlabl += 1
-    
+
     def validate(self, print_file=None):
         """Validate this MrcObject.
-        
+
         This method runs a series of tests to check whether this object
         complies strictly with the MRC2014 format specification:
-        
+
         #. MRC format ID string: The header's ``map`` field must contain
            "MAP ".
         #. Machine stamp: The machine stamp should contain one of
@@ -663,29 +706,29 @@ class MrcObject(object):
            header.
         #. Data statistics: The statistics in the header should be correct for
            the actual data, or marked as undetermined.
-        
+
         Args:
             print_file: The output text stream to use for printing messages
                 about the validation. This is passed directly to the ``file``
                 argument of Python's :func:`print` function. The default is
                 :data:`None`, which means output will be printed to
                 :data:`sys.stdout`.
-        
+
         Returns:
             :data:`True` if this MrcObject  is valid, or :data:`False` if it
             does not meet the MRC format specification in any way.
         """
         valid = True
-        
+
         def log(message):
             print(message, file=print_file)
-        
+
         # Check map ID string
         if self.header.map != MAP_ID:
             log("Map ID string is incorrect: found {0}, should be {1}"
                 .format(self.header.map, MAP_ID))
             valid = False
-        
+
         # Check machine stamp
         try:
             utils.byte_order_from_machine_stamp(self.header.machst)
@@ -693,26 +736,26 @@ class MrcObject(object):
             pretty_bytes = utils.pretty_machine_stamp(self.header.machst)
             log("Invalid machine stamp: " + pretty_bytes)
             valid = False
-        
+
         # Check mode is valid
         try:
             utils.dtype_from_mode(self.header.mode)
         except ValueError:
             log("Invalid mode: {0}".format(self.header.mode))
             valid = False
-        
+
         # Check map dimensions and other fields are non-negative
         for field in ['nx', 'ny', 'nz', 'mx', 'my', 'mz', 'ispg', 'nlabl']:
             if self.header[field] < 0:
                 log("Header field '{0}' is negative".format(field))
                 valid = False
-        
+
         # Check cell dimensions are non-negative
         for field in ['x', 'y', 'z']:
             if self.header.cella[field] < 0:
                 log("Cell dimension '{0}' is negative".format(field))
                 valid = False
-        
+
         # Check axis mapping is valid
         axes = set()
         for field in ['mapc', 'mapr', 'maps']:
@@ -721,7 +764,7 @@ class MrcObject(object):
             log("Invalid axis mapping: found {0}, should be [1, 2, 3]"
                 .format(sorted(list(axes))))
             valid = False
-        
+
         # Check mz value for volume stacks
         if utils.spacegroup_is_volume_stack(self.header.ispg):
             if self.header.nz % self.header.mz != 0:
@@ -729,7 +772,7 @@ class MrcObject(object):
                     "divisible by mz. Found nz = {0}, mz = {1})"
                     .format(self.header.nz, self.header.mz))
                 valid = False
-        
+
         # Check nlabl is correct
         count = 0
         seen_empty_label = False
@@ -746,20 +789,20 @@ class MrcObject(object):
             log("Error in header labels: nlabl is {0} "
                 "but {1} labels contain text".format(self.header.nlabl, count))
             valid = False
-        
+
         # Check MRC format version
         if self.header.nversion not in (20140, 20141):
             log("File does not declare MRC format version 20140 or 20141: nversion ="
                 " {0}".format(self.header.nversion))
             valid = False
-        
+
         # Check extended header type is set to a known value
         valid_exttypes = [b'CCP4', b'MRCO', b'SERI', b'AGAR', b'FEI1', b'FEI2', b'HDF5']
         if self.header.nsymbt > 0 and self.header.exttyp not in valid_exttypes:
             log("Extended header type is undefined or unrecognised: exttyp = "
                 "'{0}'".format(self.header.exttyp.item().decode('ascii')))
             valid = False
-        
+
         # Check data statistics
         if self.data is not None:
             real_rms = real_min = real_max = real_mean = 0
@@ -786,5 +829,5 @@ class MrcObject(object):
                 log("Data statistics appear to be inaccurate: mean is {0} but the"
                     " value in the header is {1}".format(real_mean, self.header.dmean))
                 valid = False
-        
+
         return valid

--- a/tests/test_mrcfile.py
+++ b/tests/test_mrcfile.py
@@ -41,13 +41,13 @@ except ImportError:
 
 # doc_test_dir = tempfile.mkdtemp()
 # doc_test_file = MrcFile(os.path.join(doc_test_dir, 'doc_test.mrc'), 'w+')
-# 
+#
 # def tearDownModule():
 #     global doc_test_dir, doc_test_file
 #     doc_test_file.close()
 #     if os.path.exists(doc_test_dir):
 #         shutil.rmtree(doc_test_dir)
-# 
+#
 # def load_tests(loader, tests, ignore):
 #     global doc_test_file
 #     tests.addTests(doctest.DocTestSuite(mrcfile, extraglobs={'mrc': doc_test_file}))
@@ -55,18 +55,18 @@ except ImportError:
 
 
 class MrcFileTest(MrcObjectTest):
-    
+
     """Unit tests for MRC file I/O.
-    
+
     Note that this test class inherits MrcObjectTest to ensure all of the tests
     for MrcObject work correctly for the MrcFile subclass. setUp() is a little
     more complicated as a result.
-    
+
     """
-    
+
     def setUp(self):
         super(MrcFileTest, self).setUp()
-        
+
         # Set up test files and names to be used
         self.test_data = helpers.get_test_data_path()
         self.test_output = tempfile.mkdtemp()
@@ -75,25 +75,25 @@ class MrcFileTest(MrcObjectTest):
         self.ext_header_mrc_name = os.path.join(self.test_data, 'EMD-3001.map')
         self.fei1_ext_header_mrc_name = os.path.join(self.test_data, 'fei-extended.mrc')
         self.fei2_ext_header_mrc_name = os.path.join(self.test_data, 'epu2.9_example.mrc')
-        
+
         # Set newmrc method as MrcFile constructor, to allow override by subclasses
         self.newmrc = MrcFile
-        
+
         # Set up parameters so MrcObject tests run on the MrcFile class
         obj_mrc_name = os.path.join(self.test_output, 'test_mrcobject.mrc')
         self.mrcobject = MrcFile(obj_mrc_name, 'w+')
-    
+
     def tearDown(self):
         self.mrcobject.close()
         if os.path.exists(self.test_output):
             shutil.rmtree(self.test_output)
         super(MrcFileTest, self).tearDown()
-    
+
     ############################################################################
     #
     # Tests which depend on existing files (in the test_data directory)
     #
-    
+
     def test_machine_stamp_is_read_correctly(self):
         with self.newmrc(self.example_mrc_name) as mrc:
             assert np.array_equal(mrc.header.machst, [ 0x44, 0x41, 0, 0 ])
@@ -103,12 +103,12 @@ class MrcFileTest(MrcObjectTest):
             else:
                 assert mrc.header.mode.dtype.byteorder == '<'
                 assert mrc.data.dtype.byteorder == '<'
-    
+
     def test_non_mrc_file_is_rejected(self):
         name = os.path.join(self.test_data, 'emd_3197.png')
         with (self.assertRaisesRegex(ValueError, 'Map ID string not found')):
             self.newmrc(name)
-    
+
     def test_non_mrc_file_gives_correct_warnings_in_permissive_mode(self):
         name = os.path.join(self.test_data, 'emd_3197.png')
         with warnings.catch_warnings(record=True) as w:
@@ -122,12 +122,12 @@ class MrcFileTest(MrcObjectTest):
             assert "Unrecognised machine stamp" in str(w[1].message)
             assert "Expected 976237114 bytes in extended header" in str(w[2].message)
             assert "Unrecognised mode" in str(w[3].message)
-    
+
     def test_repr(self):
         with self.newmrc(self.example_mrc_name) as mrc:
             expected = "MrcFile('{0}', mode='r')".format(self.example_mrc_name)
             assert repr(mrc) == expected
-    
+
     def test_data_values_are_correct(self):
         with self.newmrc(self.example_mrc_name) as mrc:
             # Check a few values
@@ -135,23 +135,23 @@ class MrcFileTest(MrcObjectTest):
             self.assertAlmostEqual(mrc.data[9, 6, 13], 4.6207790)
             self.assertAlmostEqual(mrc.data[9, 6, 14], 5.0373931)
             self.assertAlmostEqual(mrc.data[-1, -1, -1], 1.3078574)
-            
+
             # Calculate some statistics for all values
             calc_max = mrc.data.max()
             calc_min = mrc.data.min()
             calc_mean = mrc.data.mean(dtype=np.float64)
             calc_std = mrc.data.std()
             calc_sum = mrc.data.sum()
-            
+
             # Compare calculated values with header records
             self.assertAlmostEqual(calc_max, mrc.header.dmax)
             self.assertAlmostEqual(calc_min, mrc.header.dmin)
             self.assertAlmostEqual(calc_mean, mrc.header.dmean)
             self.assertAlmostEqual(calc_std, mrc.header.rms)
-            
+
             # Convert calc_sum to float to fix a bug with memmap comparisons in python 3
             self.assertAlmostEqual(float(calc_sum), 6268.896, places=3)
-    
+
     def test_absent_extended_header_is_read_as_zero_length_array(self):
         with self.newmrc(self.example_mrc_name) as mrc:
             assert mrc.header.nbytes == 1024
@@ -159,7 +159,7 @@ class MrcFileTest(MrcObjectTest):
             assert mrc.extended_header.nbytes == 0
             assert mrc.extended_header.dtype.kind == 'V'
             assert mrc.extended_header.tobytes() == b''
-    
+
     def test_extended_header_is_read_correctly(self):
         with self.newmrc(self.ext_header_mrc_name) as mrc:
             assert mrc.header.nbytes == 1024
@@ -172,15 +172,15 @@ class MrcFileTest(MrcObjectTest):
                               b'                                        ')
             assert ext[1] == (b'-X,  Y+1/2,  -Z                         '
                               b'                                        ')
-    
-    def test_extended_header_from_FEI1_file(self):
+
+    def test_indexed_extended_header_from_FEI1_file(self):
         with self.newmrc(self.fei1_ext_header_mrc_name) as mrc:
             # FEI1 means use the fei format
             assert mrc.header['exttyp'] == b'FEI1'
             assert mrc.header.nversion == 20140
             assert mrc.header.nsymbt == 786432
-            ext = mrc.extended_header
-            assert ext.nbytes == 786432
+            assert mrc.extended_header.nbytes == 786432
+            ext = mrc.indexed_extended_header
             assert ext.dtype.kind == 'V'
             # Most fields (e.g. Metadata size) are little-endian in this file
             assert ext.dtype['Metadata size'] == np.dtype('<i4')
@@ -192,14 +192,14 @@ class MrcFileTest(MrcObjectTest):
             assert ext[0]['Microscope type'] == b'TITAN52336320'
             assert ext[0]['HT'] == 300000.0
 
-    def test_extended_header_from_FEI2_file(self):
+    def test_indexed_extended_header_from_FEI2_file(self):
         with self.newmrc(self.fei2_ext_header_mrc_name) as mrc:
             # FEI2 means use the fei format
             assert mrc.header['exttyp'] == b'FEI2'
             assert mrc.header.nversion == 20140
             assert mrc.header.nsymbt == 909312
-            ext = mrc.extended_header
-            assert ext.nbytes == 909312
+            assert mrc.extended_header.nbytes == 909312
+            ext = mrc.indexed_extended_header
             assert ext.dtype.kind == 'V'
             # Most fields (e.g. Metadata size) are little-endian in this file
             assert ext.dtype['Metadata size'] == np.dtype('<i4')
@@ -212,25 +212,25 @@ class MrcFileTest(MrcObjectTest):
             assert ext[0]['HT'] == 300000.0
             assert ext[0]['Scan rotation'] == 0.0
             assert ext[0]['Detector commercial name'] == b''
-    
+
     def test_cannot_edit_extended_header_in_read_only_mode(self):
         with self.newmrc(self.ext_header_mrc_name, mode='r') as mrc:
             assert not mrc.extended_header.flags.writeable
             with self.assertRaisesRegex(ValueError, 'read-only'):
                 mrc.extended_header.fill(b'a')
-    
+
     def test_cannot_set_extended_header_in_read_only_mode(self):
         with self.newmrc(self.example_mrc_name, mode='r') as mrc:
             assert not mrc.extended_header.flags.writeable
             with self.assertRaisesRegex(ValueError, 'read-only'):
                 mrc.set_extended_header(np.zeros(5))
-    
+
     def test_voxel_size_is_read_correctly(self):
         with self.newmrc(self.example_mrc_name) as mrc:
             self.assertAlmostEqual(mrc.voxel_size.x, 11.400000, places=6)
             self.assertAlmostEqual(mrc.voxel_size.y, 11.400000, places=6)
             self.assertAlmostEqual(mrc.voxel_size.z, 11.400000, places=6)
-    
+
     def test_stream_can_be_read_again(self):
         with self.newmrc(self.example_mrc_name) as mrc:
             orig_data = mrc.data.copy()
@@ -242,22 +242,22 @@ class MrcFileTest(MrcObjectTest):
         path = Path(self.example_mrc_name)
         with self.newmrc(path) as mrc:
             assert self.example_mrc_name in repr(mrc)
-    
+
     ############################################################################
     #
     # Tests which do not depend on any existing files
     #
-    
+
     def test_opening_nonexistent_file(self):
         with self.assertRaisesRegex(Exception, "No such file"):
             self.newmrc('no_file')
-    
+
     def test_opening_file_with_unknown_mode(self):
         with self.newmrc(self.temp_mrc_name, mode='w+') as mrc:
             mrc.header.mode = 10
         with self.assertRaisesRegex(ValueError, "Unrecognised mode"):
             self.newmrc(self.temp_mrc_name)
-    
+
     def test_can_read_and_flush_stream_repeatedly(self):
         orig_data = np.arange(12, dtype=np.int16).reshape(3, 4)
         with self.newmrc(self.temp_mrc_name, mode='w+') as mrc:
@@ -273,25 +273,25 @@ class MrcFileTest(MrcObjectTest):
             mrc._read()
             mrc.flush()
             np.testing.assert_array_equal(orig_data, mrc.data)
-    
+
     def test_cannot_use_invalid_file_modes(self):
         for mode in ('w', 'a', 'a+'):
             with self.assertRaisesRegex(ValueError, "Mode '.+' not supported"):
                 self.newmrc(self.temp_mrc_name, mode=mode)
-    
+
     def test_cannot_accidentally_overwrite_file(self):
         assert not os.path.exists(self.temp_mrc_name)
         open(self.temp_mrc_name, 'w+').close()
         assert os.path.exists(self.temp_mrc_name)
         with self.assertRaisesRegex(ValueError, "already exists"):
             self.newmrc(self.temp_mrc_name, mode='w+')
-    
+
     def test_can_deliberately_overwrite_file(self):
         assert not os.path.exists(self.temp_mrc_name)
         open(self.temp_mrc_name, 'w+').close()
         assert os.path.exists(self.temp_mrc_name)
         self.newmrc(self.temp_mrc_name, mode='w+', overwrite=True).close()
-    
+
     def test_warning_issued_if_file_is_too_large(self):
         with self.newmrc(self.temp_mrc_name, mode='w+') as mrc:
             mrc.set_data(np.arange(12, dtype=np.int16).reshape(3, 4))
@@ -304,7 +304,7 @@ class MrcFileTest(MrcObjectTest):
             assert len(w) == 1
             assert issubclass(w[0].category, RuntimeWarning)
             assert "file is 8 bytes larger than expected" in str(w[0].message)
-    
+
     def test_exception_raised_if_file_is_too_small_for_reading_extended_header(self):
         with self.newmrc(self.temp_mrc_name, mode='w+') as mrc:
             mrc.set_data(np.arange(24, dtype=np.int16).reshape(2, 3, 4))
@@ -353,7 +353,7 @@ class MrcFileTest(MrcObjectTest):
                 assert mrc.data is None
             assert len(w) == 1
             assert issubclass(w[0].category, RuntimeWarning)
-    
+
     def test_can_edit_header_in_read_write_mode(self):
         with self.newmrc(self.temp_mrc_name, mode='w+') as mrc:
             mrc.set_data(np.arange(12, dtype=np.int16).reshape(3, 4))
@@ -362,7 +362,7 @@ class MrcFileTest(MrcObjectTest):
             assert mrc.header.flags.writeable
             mrc.header.ispg = 1
             assert mrc.header.ispg == 1
-    
+
     def test_cannot_edit_header_in_read_only_mode(self):
         with self.newmrc(self.temp_mrc_name, mode='w+') as mrc:
             mrc.set_data(np.arange(12, dtype=np.int16).reshape(3, 4))
@@ -373,7 +373,7 @@ class MrcFileTest(MrcObjectTest):
                 mrc.header.ispg = 1
         with self.newmrc(self.temp_mrc_name, mode='r') as mrc:
             assert mrc.header.ispg == 0
-    
+
     def test_creating_extended_header(self):
         data = np.arange(12, dtype=np.int16).reshape(3, 4)
         extended_header = np.array('example extended header', dtype='S')
@@ -386,7 +386,7 @@ class MrcFileTest(MrcObjectTest):
             mrc.extended_header.dtype = 'S{}'.format(mrc.extended_header.nbytes)
             np.testing.assert_array_equal(mrc.extended_header, extended_header)
             np.testing.assert_array_equal(mrc.data, data)
-    
+
     def test_removing_extended_header(self):
         data = np.arange(12, dtype=np.int16).reshape(3, 4)
         extended_header = np.array('example extended header', dtype='S')
@@ -412,12 +412,13 @@ class MrcFileTest(MrcObjectTest):
             with self.newmrc(self.temp_mrc_name, mode='r+') as mrc:
                 # Test that the file is still read, and the dtype falls back to 'V'
                 assert mrc.extended_header.dtype.kind == 'V'
+                assert mrc.indexed_extended_header is None
                 mrc.extended_header.dtype = 'S{}'.format(mrc.extended_header.nbytes)
                 np.testing.assert_array_equal(mrc.extended_header, extended_header)
             assert len(w) == 1
             assert "FEI1" in str(w[0].message)
             assert "extended header" in str(w[0].message)
-    
+
     def test_can_edit_data_in_read_write_mode(self):
         with self.newmrc(self.temp_mrc_name, mode='w+') as mrc:
             mrc.set_data(np.arange(12, dtype=np.int16).reshape(3, 4))
@@ -435,7 +436,7 @@ class MrcFileTest(MrcObjectTest):
             assert not mrc.data.flags.writeable
             with self.assertRaisesRegex(ValueError, 'read-only'):
                 mrc.data[1,1] = 0
-    
+
     def test_header_only_mode_does_not_read_data(self):
         with self.newmrc(self.temp_mrc_name, mode='w+') as mrc:
             mrc.set_data(np.arange(12, dtype=np.int16).reshape(3, 4))
@@ -448,11 +449,11 @@ class MrcFileTest(MrcObjectTest):
         x, y = 10, 9
         data = np.linspace(-128, 127, x * y, dtype=np.int8).reshape(y, x)
         name = os.path.join(self.test_output, 'test_img_10x9_mode0.mrc')
-        
+
         # Write data
         with self.newmrc(name, mode='w+') as mrc:
             mrc.set_data(data)
-        
+
         # Re-read data and check header and data values
         with self.newmrc(name) as mrc:
             np.testing.assert_array_equal(mrc.data, data)
@@ -461,88 +462,88 @@ class MrcFileTest(MrcObjectTest):
             assert mrc.header.nx == mrc.header.mx == x
             assert mrc.header.ny == mrc.header.my == y
             assert mrc.header.nz == mrc.header.mz == 1
-    
+
     def test_writing_image_unsigned_bytes(self):
         x, y = 10, 9
         data = np.linspace(0, 255, x * y, dtype=np.uint8).reshape(y, x)
         name = os.path.join(self.test_output, 'test_img_10x9_uint8.mrc')
-        
+
         # Write data
         with self.newmrc(name, mode='w+') as mrc:
             mrc.set_data(data)
-            
+
             # Check data has been converted to mode 6
             np.testing.assert_array_equal(mrc.data, data)
             assert mrc.header.mode == 6
             assert mrc.data.dtype == np.uint16
-    
+
     def write_file_then_read_and_assert_data_unchanged(self, name, data):
         with self.newmrc(name, mode='w+') as mrc:
             mrc.set_data(data)
         with self.newmrc(name) as mrc:
             np.testing.assert_array_equal(mrc.data, data)
             assert mrc.data.dtype == data.dtype
-    
+
     def test_writing_image_mode_1_native_byte_order(self):
         data = np.linspace(-32768, 32767, 90, dtype=np.int16).reshape(9, 10)
         name = os.path.join(self.test_output, 'test_img_10x9_mode1_native.mrc')
         self.write_file_then_read_and_assert_data_unchanged(name, data)
-    
+
     def test_writing_image_mode_1_little_endian(self):
         data = np.linspace(-32768, 32767, 90, dtype='<i2').reshape(9, 10)
         name = os.path.join(self.test_output, 'test_img_10x9_mode1_le.mrc')
         self.write_file_then_read_and_assert_data_unchanged(name, data)
-    
+
     def test_writing_image_mode_1_big_endian(self):
         data = np.linspace(-32768, 32767, 90, dtype='>i2').reshape(9, 10)
         name = os.path.join(self.test_output, 'test_img_10x9_mode1_be.mrc')
         self.write_file_then_read_and_assert_data_unchanged(name, data)
-    
+
     def test_writing_image_mode_2_native_byte_order(self):
         data = create_test_float32_array()
         name = os.path.join(self.test_output, 'test_img_10x9_mode2_native.mrc')
         self.write_file_then_read_and_assert_data_unchanged(name, data)
-    
+
     def test_writing_image_mode_2_little_endian(self):
         data = create_test_float32_array(np.dtype('<f4'))
         name = os.path.join(self.test_output, 'test_img_10x9_mode2_le.mrc')
         self.write_file_then_read_and_assert_data_unchanged(name, data)
-    
+
     def test_writing_image_mode_2_big_endian(self):
         data = create_test_float32_array(np.dtype('>f4'))
         name = os.path.join(self.test_output, 'test_img_10x9_mode2_be.mrc')
         self.write_file_then_read_and_assert_data_unchanged(name, data)
-    
+
     def test_writing_image_mode_2_with_inf_and_nan(self):
         # Make an array of test data
         data = create_test_float32_array()
-        
+
         # Set some unusual values
         data[4][0] = np.nan
         data[4][1] = np.inf
         data[4][2] = -np.inf
-        
+
         # Write the data to a file and test it's read back correctly
         name = os.path.join(self.test_output, 'test_img_10x9_mode2_inf_nan.mrc')
         # Suppress warnings from statistics calculations with inf and nan
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
             self.write_file_then_read_and_assert_data_unchanged(name, data)
-    
+
     def test_writing_image_float16(self):
         x, y = 10, 9
         data = np.linspace(-65504, 65504, x * y, dtype=np.float16).reshape(y, x)
         name = os.path.join(self.test_output, 'test_img_10x9_float16.mrc')
-        
+
         # Write data
         with self.newmrc(name, mode='w+') as mrc:
             mrc.set_data(data)
-            
+
             # Check data has been converted to mode 2
             np.testing.assert_array_equal(mrc.data, data)
             assert mrc.header.mode == 12
             assert mrc.data.dtype == np.float16
-    
+
     def test_writing_image_mode_4_native_byte_order(self):
         data = create_test_complex64_array()
         name = os.path.join(self.test_output, 'test_img_10x9_mode4_native.mrc')
@@ -550,7 +551,7 @@ class MrcFileTest(MrcObjectTest):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", np.ComplexWarning)
             self.write_file_then_read_and_assert_data_unchanged(name, data)
-    
+
     def test_writing_image_mode_4_little_endian(self):
         data = create_test_complex64_array().astype('<c8')
         name = os.path.join(self.test_output, 'test_img_10x9_mode4_le.mrc')
@@ -558,7 +559,7 @@ class MrcFileTest(MrcObjectTest):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", np.ComplexWarning)
             self.write_file_then_read_and_assert_data_unchanged(name, data)
-    
+
     def test_writing_image_mode_4_big_endian(self):
         data = create_test_complex64_array().astype('>c8')
         name = os.path.join(self.test_output, 'test_img_10x9_mode4_be.mrc')
@@ -566,51 +567,51 @@ class MrcFileTest(MrcObjectTest):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", np.ComplexWarning)
             self.write_file_then_read_and_assert_data_unchanged(name, data)
-    
+
     def test_writing_image_mode_4_with_inf_and_nan(self):
         # Make an array of test data
         data = create_test_complex64_array()
-        
+
         # Set some unusual values
         data[4][0] = (0 + 0j) * np.nan   # =(nan+nan*j)
         data[4][1] = (1 + 1j) * np.inf   # =(inf+inf*j)
         data[4][2] = (-1 - 1j) * np.inf  # =(-inf-inf*j)
         data[4][3] = (1 - 1j) * np.inf   # =(inf-inf*j)
         data[4][4] = (-1 + 1j) * np.inf  # =(-inf+inf*j)
-        
+
         # Write the data to a file and test it's read back correctly
         name = os.path.join(self.test_output, 'test_img_10x9_mode4_inf_nan.mrc')
         # Suppress warnings from statistics calculations with inf and nan
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
             self.write_file_then_read_and_assert_data_unchanged(name, data)
-    
+
     def test_writing_image_mode_6_native_byte_order(self):
         data = np.linspace(0, 65535, 90, dtype=np.int16).reshape(9, 10)
         name = os.path.join(self.test_output, 'test_img_10x9_mode6_native.mrc')
         self.write_file_then_read_and_assert_data_unchanged(name, data)
-    
+
     def test_writing_image_mode_6_little_endian(self):
         data = np.linspace(0, 65535, 90, dtype='<u2').reshape(9, 10)
         name = os.path.join(self.test_output, 'test_img_10x9_mode6_le.mrc')
         self.write_file_then_read_and_assert_data_unchanged(name, data)
-    
+
     def test_writing_image_mode_6_big_endian(self):
         data = np.linspace(0, 65535, 90, dtype='>u2').reshape(9, 10)
         name = os.path.join(self.test_output, 'test_img_10x9_mode6_be.mrc')
         self.write_file_then_read_and_assert_data_unchanged(name, data)
-    
+
     def test_writing_image_stack_mode_2_native_byte_order(self):
         x, y, z = 10, 9, 5
         img = np.linspace(-1e6, 1e6, x * y, dtype=np.float32).reshape(y, x)
         stack = np.arange(1, 6, dtype=np.float32).reshape(z, 1, 1) * img
         name = os.path.join(self.test_output, 'test_img_stack_10x9x5_mode2_native.mrc')
-        
+
         # Write data
         with self.newmrc(name, mode='w+') as mrc:
             mrc.set_data(stack)
             mrc.set_image_stack()
-        
+
         # Re-read data and check header and data values
         with self.newmrc(name) as mrc:
             np.testing.assert_array_equal(mrc.data, stack)
@@ -620,17 +621,17 @@ class MrcFileTest(MrcObjectTest):
             assert mrc.header.ny == mrc.header.my == y
             assert mrc.header.mz == 1
             assert mrc.header.nz == z
-    
+
     def test_writing_volume_mode_1_native_byte_order(self):
         x, y, z = 10, 9, 5
         img = np.linspace(-32768, 32767, x * y, dtype=np.int16).reshape(y, x)
         vol = img // np.arange(1, 6, dtype=np.int16).reshape(z, 1, 1)
         name = os.path.join(self.test_output, 'test_vol_10x9x5_mode1_native.mrc')
-        
+
         # Write data
         with self.newmrc(name, mode='w+') as mrc:
             mrc.set_data(vol)
-        
+
         # Re-read data and check header and data values
         with self.newmrc(name) as mrc:
             np.testing.assert_array_equal(mrc.data, vol)
@@ -638,18 +639,18 @@ class MrcFileTest(MrcObjectTest):
             assert mrc.header.nx == mrc.header.mx == x
             assert mrc.header.ny == mrc.header.my == y
             assert mrc.header.mz == mrc.header.nz == z
-    
+
     def test_writing_volume_stack_mode_1_native_byte_order(self):
         x, y, z, nvol = 10, 9, 5, 3
         img = np.linspace(-32768, 32767, x * y, dtype=np.int16).reshape(y, x)
         vol = img // np.arange(1, 6, dtype=np.int16).reshape(z, 1, 1)
         stack = vol * np.array([-1, 0, 1], dtype=np.int16).reshape(nvol, 1, 1, 1)
         name = os.path.join(self.test_output, 'test_vol_stack_10x9x5x3_mode1_native.mrc')
-        
+
         # Write data
         with self.newmrc(name, mode='w+') as mrc:
             mrc.set_data(stack)
-        
+
         # Re-read data and check header and data values
         with self.newmrc(name) as mrc:
             np.testing.assert_array_equal(mrc.data, stack)
@@ -658,7 +659,7 @@ class MrcFileTest(MrcObjectTest):
             assert mrc.header.ny == mrc.header.my == y
             assert mrc.header.mz == z
             assert mrc.header.nz == z * nvol
-    
+
     def test_data_transposed_in_place_is_written_without_errors(self):
         # Quite unlikely that anyone will mess with the data array like this,
         # but still worth making sure the flush() call is robust!
@@ -666,27 +667,27 @@ class MrcFileTest(MrcObjectTest):
         img = np.linspace(-32768, 32767, x * y, dtype=np.int16).reshape(y, x)
         vol = img // np.arange(1, 6, dtype=np.int16).reshape(z, 1, 1)
         transposed_vol = vol.transpose()
-        
+
         # Write data and confirm it's C-contiguous
         mrc = self.newmrc(self.temp_mrc_name, mode='w+')
         mrc.set_data(vol)
         mrc.flush()
         assert mrc.data.flags.c_contiguous == True
-        
+
         # Transpose the data array in-place
         strides = mrc.data.strides
         mrc.data.shape = mrc.data.shape[::-1]
         mrc.data.strides = strides[::-1]
         # Check this is an effective way to do in-place transpose()
         np.testing.assert_array_equal(transposed_vol, mrc.data)
-        
+
         # Confirm data is no longer C-contiguous
         assert mrc.data.flags.c_contiguous == False
-        
+
         # Flush and close should work without errors
         mrc.flush()
         mrc.close()
-    
+
     def test_transposed_data_is_made_contiguous_on_set(self):
         # Quite unlikely that anyone will mess with the data array like this,
         # but still worth making sure the flush() call is robust!
@@ -694,9 +695,9 @@ class MrcFileTest(MrcObjectTest):
         img = np.linspace(-32768, 32767, x * y, dtype=np.int16).reshape(y, x)
         vol = img // np.arange(1, 6, dtype=np.int16).reshape(z, 1, 1)
         vol = vol.transpose()
-        
+
         assert vol.flags.c_contiguous == False
-        
+
         # Write data and confirm it's C-contiguous
         with self.newmrc(self.temp_mrc_name, mode='w+') as mrc:
             mrc.set_data(vol)


### PR DESCRIPTION
This PR adds a new property, `MrcObject.indexed_extended_header`. This will return an FEI1 or FEI2 extended header as an array of metadata blocks with the expected size, even if the extended header data is zero-padded at the end.

The `MrcObject.extended_header` property no longer attempts to set any `dtype` other than `'V'` (void). This is a behaviour change that may affect downstream users! If this is a concern, I could rework this so that `extended_header` has the appropriate `dtype` set in cases where there is not zero-padding, thus restoring previous behaviour. However, that might lead to a confusing difference in behaviour when interpreting files with zero-padded and non-zero-padded extended headers. I felt it was cleaner to insist that the extended header bytes are presented without interpretation. Interpreting as FEI1 or FEI2 headers is therefore an extra explicit convenience step.