### PR TITLE
Fix overflow error when file size is large

### DIFF
--- a/mrcfile/mrcmemmap.py
+++ b/mrcfile/mrcmemmap.py
@@ -114,7 +114,7 @@ class MrcMemmap(MrcFile):
     def _open_memmap(self, dtype, shape):
         """Open a new memmap array pointing at the file's data block."""
         acc_mode = 'r' if self._read_only else 'r+'
-        header_nbytes = self.header.nbytes + self.header.nsymbt
+        header_nbytes = int(self.header.nbytes + self.header.nsymbt)
         
         self._iostream.flush()
         try:


### PR DESCRIPTION
This PR fixes overflow error of `mrcfile.open` and `mrcfile.mmap`.

I was using `mrcfile` in combination with `numpy=v2.0.0`, and I found that opening an mrc file raises overflow error if the file size is larger than the depth of `np.int32`.
The reason was because the `header_nbytes` variable is `np.int32`, which is used for the `-=` operation inside `np.memmap`.