### PR TITLE
fix overflow errors when opening files bigger than np.int32.max bytes

### DIFF
--- a/mrcfile/mrcfile.py
+++ b/mrcfile/mrcfile.py
@@ -133,7 +133,8 @@ class MrcFile(MrcInterpreter):
     def _read_data(self):
         """Override _read_data() to check file size matches data block size."""
         file_size = self._get_file_size()
-        header_size = self.header.nbytes + self.header.nsymbt
+        #int casting is needed to prevent OverflowErrors
+        header_size = int(self.header.nbytes + self.header.nsymbt)
         remaining_file_size = file_size - header_size
 
         super(MrcFile, self)._read_data(max_bytes=remaining_file_size)


### PR DESCRIPTION
Similar as #61 

Code to reproduce:
```python
# Write mrcfile of ~2.1GB, which can't be opened anymore
import numpy as np
import mrcfile
from tempfile import TemporaryDirectory

with TemporaryDirectory() as temp_dir:
    max_n_values = np.iinfo(np.int32).max
    # needs to be 2,3 or 4D: pick 3D
    value_per_dim = int(np.ceil((max_n_values/4)**(1/3)))
    array = np.zeros([value_per_dim]*3, dtype=np.float32)
    f = mrcfile.new(temp_dir+'test.mrc', data=array, overwrite=True)
    f.close()
    mrcfile.open(temp_dir+'test.mrc')
```