### PR TITLE
Fix DeprecationWarning when setting header.dtype on NumPy 2.5+

### DIFF
--- a/src/mrcfile/mrcinterpreter.py
+++ b/src/mrcfile/mrcinterpreter.py
@@ -222,9 +222,9 @@ class MrcInterpreter(MrcObject):
                 raise
 
         # Create a new dtype with the correct byte order and update the header
-        # Assigning to .dtype is discouraged but not yet deprecated, and none of the
-        # other methods (view, astype) achieve quite what we need here
-        header.dtype = header.dtype.newbyteorder(byte_order)  # type: ignore[misc]
+        # by viewing it as the new dtype. (Assigning to .dtype directly is
+        # deprecated since NumPy 2.5.)
+        header = header.view(header.dtype.newbyteorder(byte_order))
 
         # Check mode is valid; if not, try the opposite byte order
         # (Some MRC files have been seen 'in the wild' that are correct except
@@ -237,11 +237,9 @@ class MrcInterpreter(MrcObject):
                     opp_mode = header.mode.view(header.mode.dtype.newbyteorder())
                     utils.dtype_from_mode(opp_mode)
                     # If we get here the new byte order is probably correct
-                    # Use it and issue a warning
-                    # Assigning to .dtype is discouraged but not yet deprecated, and
-                    # none of the other methods (view, astype) achieve quite what we
-                    # need here
-                    header.dtype = header.dtype.newbyteorder()  # type: ignore[misc]
+                    # Use it and issue a warning. (Assigning to .dtype directly is
+                    # deprecated since NumPy 2.5.)
+                    header = header.view(header.dtype.newbyteorder())
                     pretty_machst = utils.pretty_machine_stamp(header.machst)
                     warnings.warn(
                         f"Machine stamp '{pretty_machst}' does not match the apparent"

--- a/src/mrcfile/mrcobject.py
+++ b/src/mrcfile/mrcobject.py
@@ -228,9 +228,8 @@ class MrcObject:
             if self.extended_header.nbytes < dtype.itemsize:
                 raise ValueError  # noqa: TRY301
             first = self.extended_header[0 : dtype.itemsize]
-            # Assigning to .dtype is discouraged but not yet deprecated, and none of the
-            # other methods (view, astype) achieve quite what we need here
-            first.dtype = dtype  # type: ignore[misc]
+            # Assigning to .dtype directly is deprecated since NumPy 2.5
+            first = first.view(dtype)
             if first["Metadata size"][0] != dtype.itemsize:
                 raise ValueError  # noqa: TRY301
         except ValueError:
@@ -246,9 +245,8 @@ class MrcObject:
             if self.extended_header.nbytes < nbytes:
                 raise ValueError  # noqa: TRY301
             full = self.extended_header[0:nbytes]
-            # Assigning to .dtype is discouraged but not yet deprecated, and none of the
-            # other methods (view, astype) achieve quite what we need here
-            full.dtype = dtype  # type: ignore[misc]
+            # Assigning to .dtype directly is deprecated since NumPy 2.5
+            full = full.view(dtype)
         except ValueError:
             warnings.warn(
                 f"The header has exttyp '{self.header.exttyp}' but the extended header"
@@ -650,9 +648,11 @@ class MrcObject:
             data_byte_order, header_byte_order
         ):
             header.byteswap(inplace=True)
-            # Assigning to .dtype is discouraged but not yet deprecated, and none of the
-            # other methods (view, astype) achieve quite what we need here
-            header.dtype = header.dtype.newbyteorder(data_byte_order)  # type: ignore[misc]
+            # Assigning to .dtype directly is deprecated since NumPy 2.5, so view the
+            # header as the new dtype instead, and store the result back onto
+            # self._header since the view is a new array, not the original.
+            header = header.view(header.dtype.newbyteorder(data_byte_order))
+            self._header = header
         header.machst = utils.machine_stamp_from_byte_order(header.mode.dtype.byteorder)  # type: ignore[attr-defined]  # mypy thinks header.mode is an ``int``
 
         shape = self.data.shape

--- a/tests/test_mrcfile.py
+++ b/tests/test_mrcfile.py
@@ -146,8 +146,7 @@ class MrcFileTest(test_mrcobject.MrcObjectTest):
             assert mrc.header.nsymbt == 160
             assert mrc.extended_header.nbytes == 160
             assert mrc.extended_header.dtype.kind == "V"
-            mrc.extended_header.dtype = "S80"
-            ext = mrc.extended_header
+            ext = mrc.extended_header.view("S80")
             assert ext[0] == (
                 b"X,  Y,  Z                               "
                 b"                                        "
@@ -372,8 +371,8 @@ class MrcFileTest(test_mrcobject.MrcObjectTest):
             np.testing.assert_array_equal(mrc.data, data)
         with self.newmrc(self.temp_mrc_name, mode="r") as mrc:
             # Change the extended header dtype to a string for comparison
-            mrc.extended_header.dtype = f"S{mrc.extended_header.nbytes}"
-            np.testing.assert_array_equal(mrc.extended_header, extended_header)
+            ext = mrc.extended_header.view(f"S{mrc.extended_header.nbytes}")
+            np.testing.assert_array_equal(ext, extended_header)
             np.testing.assert_array_equal(mrc.data, data)
 
     def test_removing_extended_header(self):
@@ -402,8 +401,8 @@ class MrcFileTest(test_mrcobject.MrcObjectTest):
                 # Test that the file is still read, and the dtype falls back to 'V'
                 assert mrc.extended_header.dtype.kind == "V"
                 assert mrc.indexed_extended_header is None
-                mrc.extended_header.dtype = f"S{mrc.extended_header.nbytes}"
-                np.testing.assert_array_equal(mrc.extended_header, extended_header)
+                ext = mrc.extended_header.view(f"S{mrc.extended_header.nbytes}")
+                np.testing.assert_array_equal(ext, extended_header)
             assert len(w) == 1
             assert "FEI1" in str(w[0].message)
             assert "extended header" in str(w[0].message)

--- a/tests/test_mrcobject.py
+++ b/tests/test_mrcobject.py
@@ -385,11 +385,13 @@ class MrcObjectTest(unittest.TestCase):
         assert utils.byte_orders_equal(header.mode.dtype.byteorder, orig_byte_order)
 
         self.mrcobject.set_data(data.view(data.dtype.newbyteorder()))
+        header = self.mrcobject.header
         assert not utils.byte_orders_equal(header.mode.dtype.byteorder, orig_byte_order)
         assert header.mode == 2
         assert header.mapc == original_mapc
 
         self.mrcobject.set_data(data)
+        header = self.mrcobject.header
         assert utils.byte_orders_equal(header.mode.dtype.byteorder, orig_byte_order)
         assert header.mode == 2
         assert header.mapc == original_mapc


### PR DESCRIPTION
@colinpalmer Just a heads up, I thought I would have a fix at solving this issue with claude because it seemed simple enough, but that might not be the case.

Mainly the original code had this comment which this PR exactly changes. From the text it's not immediately clear to me what mrcfile is trying to achieve here specifically with dtype assigning:

```
# Assigning to .dtype is discouraged but not yet deprecated, and
# none of the other methods (view, astype) achieve quite what we
# need here
```

but my guess its because of maintaining the original object, which is no longer possible with 2.5, so some fix is definitely needed.

---

  Summary of the fix (closes ccpem/mrcfile#75):
  - Replaced all in-place header.dtype = .../arr.dtype = ... mutations with .view(new_dtype) in mrcinterpreter.py and mrcobject.py, since numpy
  2.5 deprecates in-place dtype assignment entirely (confirmed for plain ndarray too, not just recarray — no in-place-safe alternative exists).
  - One spot (update_header_from_data) required reassigning self._header since .view() returns a new object; this is a small behavior change. A header reference grabbed before calling set_data() with byte-swapped data no longer auto-reflects the byte-order change. Updated the
  one affected test (test_header_byte_order_is_changed_by_data_with_opposite_order) to re-fetch mrc.header instead.
  - Fixed three test-code call sites in test_mrcfile.py using the same deprecated pattern.
  - Verified against the issue's exact repro script, the full test suite (861 tests) in both the existing environment and a fresh conda env with Python 3.14 + numpy 2.5.0, plus mypy and ruff — all clean.

Closes #75



